### PR TITLE
build: add CI workflow to ensure CI checks pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+  pull_request:
+    branches:
+      - main
+      - dev
+
+permissions:
+  checks: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        node: [16]
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Setup node env 📦
+        uses: actions/setup-node@v2.4.0
+        with:
+          node-version: ${{ matrix.node }}
+          registry-url: 'https://registry.npmjs.org'
+          check-latest: true
+          cache: 'npm'
+
+      - name: Upgrade npm ✨
+        run: npm i -g npm@latest
+
+      - name: Install dependencies 🛠
+        run: npm ci --prefer-offline --no-audit --no-optional
+
+      - name: Run linter(s) 👀
+        uses: wearerequired/lint-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          continue_on_error: true
+          git_name: github-actions[bot]
+          git_email: github-actions[bot]@users.noreply.github.com
+          auto_fix: false
+          stylelint: false
+          eslint: true
+          eslint_extensions: js,ts,vue
+          prettier: true
+          prettier_extensions: js,ts,vue
+          neutral_check_on_warning: true
+
+      - name: Generate the static docs site ⚡️
+        run: npm run build


### PR DESCRIPTION
- [x] Enables CI workflow to ensure the site does not break when new changes are added `npm run build` step in the CI.
- [x] Also it ensures that code is linted as per eslint, stylelint & prettier standards.